### PR TITLE
Generation of Role keys & Share keys

### DIFF
--- a/config/schema/key.provider.pubkey_encrypt.schema.yml
+++ b/config/schema/key.provider.pubkey_encrypt.schema.yml
@@ -1,0 +1,13 @@
+key.provider.pubkey_encrypt:
+  type: mapping
+  label: 'Pubkey Encrypt key provider settings'
+  mapping:
+    role:
+     type: string
+     label: 'Role name'
+    share_keys:
+      type: sequence
+      label: 'Share keys'
+      sequence:
+        type: string
+        label: 'Share key for a specific user'

--- a/pubkey_encrypt.install
+++ b/pubkey_encrypt.install
@@ -60,4 +60,7 @@ function pubkey_encrypt_install() {
     ->removeComponent('field_private_key')
     ->removeComponent('field_private_key_protected')
     ->save();
+
+  // Generate Role keys.
+  $pubkey_encrypt_manager->generateRoleKeys();
 }

--- a/pubkey_encrypt.install
+++ b/pubkey_encrypt.install
@@ -39,7 +39,7 @@ function pubkey_encrypt_requirements($phase) {
  * Implements hook_install().
  */
 function pubkey_encrypt_install() {
-  // Initialize all keys.
+  // Initialize all User keys.
   $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
   $pubkey_encrypt_manager->initializeAllUserKeys();
 
@@ -61,6 +61,6 @@ function pubkey_encrypt_install() {
     ->removeComponent('field_private_key_protected')
     ->save();
 
-  // Generate Role keys.
-  $pubkey_encrypt_manager->generateRoleKeys();
+  // Initialize all Role keys.
+  $pubkey_encrypt_manager->initializeRoleKeys();
 }

--- a/pubkey_encrypt.module
+++ b/pubkey_encrypt.module
@@ -97,6 +97,7 @@ function pubkey_encrypt_user_role_insert(\Drupal\user\RoleInterface $role) {
  * Implements hook_user_update().
  */
 function pubkey_encrypt_user_update(\Drupal\user\UserInterface $account) {
+  // Check if the user roles have been modified.
   $new_roles = $account->getRoles();
   $previous_roles = $account->original->getRoles();
 
@@ -105,8 +106,9 @@ function pubkey_encrypt_user_update(\Drupal\user\UserInterface $account) {
     $removed_roles = array_diff($previous_roles, $new_roles);
     $changed_roles = array_merge($added_roles, $removed_roles);
 
+    // Update Role keys.
+    $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
     foreach ($changed_roles as $role) {
-      $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
       $pubkey_encrypt_manager
         ->updateRoleKey(\Drupal\user\Entity\Role::load($role));
     }

--- a/pubkey_encrypt.module
+++ b/pubkey_encrypt.module
@@ -79,7 +79,7 @@ function pubkey_encrypt_user_insert(\Drupal\Core\Entity\EntityInterface $entity)
  * Implements hook_user_role_delete().
  */
 function pubkey_encrypt_user_role_delete(\Drupal\user\RoleInterface $role) {
-  // Cater for Role deletion.
+  // Delete the Role key upon Role deletion.
   $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
   $pubkey_encrypt_manager->deleteRoleKey($role);
 }
@@ -88,7 +88,7 @@ function pubkey_encrypt_user_role_delete(\Drupal\user\RoleInterface $role) {
  * Implements hook_user_role_insert().
  */
 function pubkey_encrypt_user_role_insert(\Drupal\user\RoleInterface $role) {
-  // Cater for Role creation.
+  // Create a Role key upon Role creation.
   $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
   $pubkey_encrypt_manager->generateRoleKey($role);
 }

--- a/pubkey_encrypt.module
+++ b/pubkey_encrypt.module
@@ -82,6 +82,13 @@ function pubkey_encrypt_user_role_delete(\Drupal\user\RoleInterface $role) {
   // Delete the Role key upon Role deletion.
   $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
   $pubkey_encrypt_manager->deleteRoleKey($role);
+
+  // If the role had "administer permissions" permission in it, we need to
+  // update all Role keys. This would cause all users updated with "administer
+  // permissions" permission get complete control over all Role keys.
+  if ($role->hasPermission("administer permissions")) {
+    $pubkey_encrypt_manager->updateAllRoleKeys();
+  }
 }
 
 /**
@@ -109,8 +116,37 @@ function pubkey_encrypt_user_update(\Drupal\user\UserInterface $account) {
     // Update Role keys.
     $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
     foreach ($changed_roles as $role) {
+      $role = \Drupal\user\Entity\Role::load($role);
+
+      // We need to update all Role keys if any changed role has "administer
+      // permissions" permission in it.
+      if ($role->hasPermission("administer permissions")) {
+        // This would cause all users updated with "administer permissions"
+        // permission get complete control over all Role keys.
+        $pubkey_encrypt_manager->updateAllRoleKeys();
+
+        // Break the loop as all Role keys just got updated so moving forward
+        // is unnecessary.
+        break;
+      }
+
+      // Otherwise just update the specific Role key.
       $pubkey_encrypt_manager
-        ->updateRoleKey(\Drupal\user\Entity\Role::load($role));
+        ->updateRoleKey($role);
     }
+  }
+}
+
+/**
+ * Implements hook_user_role_update().
+ */
+function pubkey_encrypt_user_role_update(\Drupal\user\RoleInterface $role) {
+  // If a Role is given "administer permissions" permission, trigger the Role
+  // key updates.
+  if ($role->hasPermission("administer permissions") != $role->original->hasPermission("administer permissions")) {
+    $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
+    // This would cause all users updated with "administer permissions"
+    // permission get complete control over all Role keys.
+    $pubkey_encrypt_manager->updateAllRoleKeys();
   }
 }

--- a/pubkey_encrypt.module
+++ b/pubkey_encrypt.module
@@ -74,3 +74,41 @@ function pubkey_encrypt_user_insert(\Drupal\Core\Entity\EntityInterface $entity)
   $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
   $pubkey_encrypt_manager->initializeUserKeys($entity);
 }
+
+/**
+ * Implements hook_user_role_delete().
+ */
+function pubkey_encrypt_user_role_delete(\Drupal\user\RoleInterface $role) {
+  // Cater for Role deletion.
+  $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
+  $pubkey_encrypt_manager->deleteRoleKey($role);
+}
+
+/**
+ * Implements hook_user_role_insert().
+ */
+function pubkey_encrypt_user_role_insert(\Drupal\user\RoleInterface $role) {
+  // Cater for Role creation.
+  $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
+  $pubkey_encrypt_manager->generateRoleKey($role);
+}
+
+/**
+ * Implements hook_user_update().
+ */
+function pubkey_encrypt_user_update(\Drupal\user\UserInterface $account) {
+  $new_roles = $account->getRoles();
+  $previous_roles = $account->original->getRoles();
+
+  if ($new_roles != $previous_roles) {
+    $added_roles = array_diff($new_roles, $previous_roles);
+    $removed_roles = array_diff($previous_roles, $new_roles);
+    $changed_roles = array_merge($added_roles, $removed_roles);
+
+    foreach ($changed_roles as $role) {
+      $pubkey_encrypt_manager = \Drupal::service('pubkey_encrypt.pubkey_encrypt_manager');
+      $pubkey_encrypt_manager
+        ->updateRoleKey(\Drupal\user\Entity\Role::load($role));
+    }
+  }
+}

--- a/pubkey_encrypt.module
+++ b/pubkey_encrypt.module
@@ -150,3 +150,35 @@ function pubkey_encrypt_user_role_update(\Drupal\user\RoleInterface $role) {
     $pubkey_encrypt_manager->updateAllRoleKeys();
   }
 }
+
+/**
+ * Implements hook_modules_installed().
+ */
+function pubkey_encrypt_modules_installed($modules) {
+  // Force logout all users after Pubkey Encrypt module installation.
+  if (in_array('pubkey_encrypt', $modules)) {
+    // Logout the current user, if any.
+    if (\Drupal::currentUser()->isAnonymous() != TRUE) {
+      user_logout();
+    }
+    // Logout all other active users on the website.
+    $connection = \Drupal::service('database');
+    $result = $connection
+      ->select('sessions', 's')
+      ->fields('s', array('uid', 'sid'))
+      ->execute();
+    while ($session = $result->fetch()) {
+      // Invoke hook_user_logout for a user before removing his session.
+      $user = \Drupal::entityTypeManager()
+        ->getStorage('user')
+        ->load($session->uid);
+      \Drupal::moduleHandler()->invokeAll('user_logout', array($user));
+
+      // Remove the user session.
+      $connection
+        ->delete('sessions')
+        ->condition('sid', $session->sid)
+        ->execute();
+    }
+  }
+}

--- a/src/Plugin/KeyProvider/PubkeyEncryptKeyProvider.php
+++ b/src/Plugin/KeyProvider/PubkeyEncryptKeyProvider.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\pubkey_encrypt\Plugin\KeyProvider\PubkeyEncryptKeyProvider.
+ */
+
+namespace Drupal\pubkey_encrypt\Plugin\KeyProvider;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\key\Plugin\KeyProviderBase;
+use Drupal\key\Plugin\KeyPluginFormInterface;
+use Drupal\key\Plugin\KeyProviderSettableValueInterface;
+use Drupal\key\KeyInterface;
+use Drupal\user\Entity\Role;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Adds a key provider as per the requirements of Pubkey Encrypt module.
+ *
+ * @KeyProvider(
+ *   id = "pubkey_encrypt",
+ *   label = @Translation("Pubkey Encrypt"),
+ *   description = @Translation("Stores and Retrieves the key as per the requirements of Pubkey Encrypt module."),
+ *   storage_method = "pubkey_encrypt",
+ *   key_value = {
+ *     "accepted" = TRUE,
+ *     "required" = TRUE
+ *   }
+ * )
+ */
+class PubkeyEncryptKeyProvider extends KeyProviderBase implements KeyPluginFormInterface, KeyProviderSettableValueInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $roleOptions = [];
+    foreach (Role::loadMultiple() as $role) {
+      $roleOptions[$role->id()] = $role->label();
+    }
+    unset($roleOptions[AccountInterface::ANONYMOUS_ROLE]);
+    unset($roleOptions[AccountInterface::AUTHENTICATED_ROLE]);
+
+    $form['role'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Role'),
+      '#description' => $this->t('Share keys would be generated and stored for all the users in this Role.'),
+      '#options' => $roleOptions,
+      '#default_value' => $this->getConfiguration()['role'],
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $this->setConfiguration($form_state->getValues());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getKeyValue(KeyInterface $key) {
+    $key_value = '';
+
+    $currentUserId = \Drupal::currentUser()->id();
+
+    // Retrieve the actual key value from the Share key of user.
+    $shareKeys = $this->configuration['share_keys'];
+    if (isset($shareKeys[$currentUserId])) {
+      $shareKey = base64_decode($shareKeys[$currentUserId]);
+
+      // The Private key of the user should be here, if the user is logged in.
+      $tempstore = \Drupal::service('user.private_tempstore')
+        ->get('pubkey_encrypt');
+      $privateKey = $tempstore->get('private_key');
+
+      openssl_private_decrypt($shareKey, $decrypted, $privateKey);
+      $key_value = $decrypted;
+    }
+
+    return $key_value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setKeyValue(KeyInterface $key, $key_value) {
+    // Generate Share keys for all users from the specified role.
+    $role = $this->configuration['role'];
+    $shareKeys = [];
+    $users = \Drupal::service('entity_type.manager')
+      ->getStorage('user')
+      ->loadByProperties(['roles' => $role]);
+    // Each user will have a Share key.
+    foreach ($users as $user) {
+      $userId = $user->get('uid')->getString();
+      $publicKey = $user->get('field_public_key')->getString();
+      openssl_public_encrypt($key_value, $shareKey, $publicKey);
+      $shareKeys[$userId] = base64_encode($shareKey);
+    }
+
+    // Store the Share keys.
+    $this->configuration['share_keys'] = $shareKeys;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteKeyValue(KeyInterface $key) {
+    // Nothing needs to be done, since the value will have been deleted
+    // with the Key entity.
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function obscureKeyValue($key_value, array $options = []) {
+    // Key values are not obscured when this provider is used.
+    return $key_value;
+  }
+
+}

--- a/src/Plugin/KeyProvider/PubkeyEncryptKeyProvider.php
+++ b/src/Plugin/KeyProvider/PubkeyEncryptKeyProvider.php
@@ -79,7 +79,7 @@ class PubkeyEncryptKeyProvider extends KeyProviderBase implements KeyPluginFormI
     // Retrieve the actual key value from the Share key of user.
     $shareKeys = $this->configuration['share_keys'];
     if (isset($shareKeys[$currentUserId])) {
-      $shareKey = base64_decode($shareKeys[$currentUserId]);
+      $shareKey = $shareKeys[$currentUserId];
 
       // The Private key of the user should be here, if the user is logged in.
       $tempstore = \Drupal::service('user.private_tempstore')
@@ -112,7 +112,7 @@ class PubkeyEncryptKeyProvider extends KeyProviderBase implements KeyPluginFormI
         $userId = $user->get('uid')->getString();
         $publicKey = $user->get('field_public_key')->getString();
         openssl_public_encrypt($key_value, $shareKey, $publicKey);
-        $shareKeys[$userId] = base64_encode($shareKey);
+        $shareKeys[$userId] = $shareKey;
       }
     }
 

--- a/src/PubkeyEncryptManager.php
+++ b/src/PubkeyEncryptManager.php
@@ -163,8 +163,7 @@ class PubkeyEncryptManager {
     $values["description"] = $role_label . " Role key used by Pubkey Encrypt";
     $values["key_type"] = "encryption";
     $values["key_type_settings"]["key_size"] = "128";
-    $values["key_input"] = "text_field";
-    $values["key_input_settings"]["base64_encoded"] = TRUE;
+    $values["key_input"] = "none";
     $values["key_provider"] = "pubkey_encrypt";
     $values["key_provider_settings"]["role"] = $role_id;
     \Drupal::entityTypeManager()

--- a/src/PubkeyEncryptManager.php
+++ b/src/PubkeyEncryptManager.php
@@ -188,9 +188,9 @@ class PubkeyEncryptManager {
   }
 
   /*
-   * Generate Role keys upon module installation.
+   * Initialize Role keys upon module installation.
    */
-  public function generateRoleKeys() {
+  public function initializeRoleKeys() {
     // Generate a Role key per role.
     foreach (Role::loadMultiple() as $role) {
       if ($role->id() != AccountInterface::ANONYMOUS_ROLE && $role->id() != AccountInterface::AUTHENTICATED_ROLE) {

--- a/src/Tests/RoleKeysManagement.php
+++ b/src/Tests/RoleKeysManagement.php
@@ -8,6 +8,7 @@
 namespace Drupal\pubkey_encrypt\Tests;
 
 use Drupal\simpletest\WebTestBase;
+use Drupal\user\Entity\Role;
 
 /**
  * Tests the management of Role keys.
@@ -44,11 +45,7 @@ class RoleKeysManagement extends WebTestBase {
     $user2 = $this->drupalCreateUser(array());
 
     // Login with root user.
-    $admin = $this->drupalCreateUser(array(
-      'administer users',
-      'administer permissions',
-    ));
-    $this->drupalLogin($admin);
+    $this->drupalLogin($this->rootUser);
 
     // Add user1 to the newly created role.
     $edit = array();
@@ -59,7 +56,7 @@ class RoleKeysManagement extends WebTestBase {
     $this->drupalLogin($user1);
     $role_key_value = $key_repository
       ->getKey($new_role_id . "_role_key")
-      ->getKeyValue();
+      ->getKeyValue(TRUE);
 
     $this->assertNotEqual('', $role_key_value, "A user is able to access Role key value if he is in the role");
 
@@ -68,14 +65,18 @@ class RoleKeysManagement extends WebTestBase {
     $this->drupalLogin($user2);
     $role_key_value = $key_repository
       ->getKey($new_role_id . "_role_key")
-      ->getKeyValue();
+      ->getKeyValue(TRUE);
 
     $this->assertEqual('', $role_key_value, "A user is not able to access Role key value if he is not in the role");
 
     // Remove the role.
-    //\Drupal::entityTypeManager()->getStorage('user')->delete(array("id" => $new_role_id));
-    //$new_role_key = $key_repository->getKey($new_role_id . "_role_key");
-    //$this->assertNull($new_role_key, "Role key gets deleted upon the deletion of a role");
+    \Drupal::entityTypeManager()
+      ->getStorage('user_role')
+      ->delete(array(Role::load($new_role_id)));
+
+    // Test that the Role key has been deleted.
+    $new_role_key = $key_repository->getKey($new_role_id . "_role_key");
+    $this->assertNull($new_role_key, "Role key gets deleted upon the deletion of a role");
   }
 
 }

--- a/src/Tests/RoleKeysManagement.php
+++ b/src/Tests/RoleKeysManagement.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @file
+ * Definition of Drupal\password_policy\Tests\PasswordManualReset.
+ */
+
+namespace Drupal\pubkey_encrypt\Tests;
+
+use Drupal\simpletest\WebTestBase;
+
+/**
+ * Tests the management of Role keys.
+ *
+ * @group pubkey_encrypt
+ */
+class RoleKeysManagement extends WebTestBase {
+
+  public static $modules = array(
+    'key',
+    'encrypt',
+    'pubkey_encrypt',
+
+  );
+
+  protected $profile = 'minimal';
+
+  /**
+   * Test Role keys.
+   */
+  public function testRoleKeys() {
+    // Key Repository service.
+    $key_repository = \Drupal::service('key.repository');
+
+    // Create a new role.
+    $new_role_id = $this->drupalCreateRole(array());
+
+    // Test that a Role key has been created.
+    $new_role_key = $key_repository->getKey($new_role_id . "_role_key");
+    $this->assertNotNull($new_role_key, "Role key gets created upon the creation of a role");
+
+    // Create two new users.
+    $user1 = $this->drupalCreateUser(array());
+    $user2 = $this->drupalCreateUser(array());
+
+    // Login with root user.
+    $admin = $this->drupalCreateUser(array(
+      'administer users',
+      'administer permissions',
+    ));
+    $this->drupalLogin($admin);
+
+    // Add user1 to the newly created role.
+    $edit = array();
+    $edit['roles[' . $new_role_id . ']'] = $new_role_id;
+    $this->drupalPostForm("user/" . $user1->id() . "/edit", $edit, t('Save'));
+
+    // Test user1 is able to access the Role key because he is in the role.
+    $this->drupalLogin($user1);
+    $role_key_value = $key_repository
+      ->getKey($new_role_id . "_role_key")
+      ->getKeyValue();
+
+    $this->assertNotEqual('', $role_key_value, "A user is able to access Role key value if he is in the role");
+
+    // Test user2 is not able to access the Role key because he is not in the
+    // role.
+    $this->drupalLogin($user2);
+    $role_key_value = $key_repository
+      ->getKey($new_role_id . "_role_key")
+      ->getKeyValue();
+
+    $this->assertEqual('', $role_key_value, "A user is not able to access Role key value if he is not in the role");
+
+    // Remove the role.
+    //\Drupal::entityTypeManager()->getStorage('user')->delete(array("id" => $new_role_id));
+    //$new_role_key = $key_repository->getKey($new_role_id . "_role_key");
+    //$this->assertNull($new_role_key, "Role key gets deleted upon the deletion of a role");
+  }
+
+}


### PR DESCRIPTION
- Implements a key provider.
- The key provider doesn't store a key value (i.e. role key) in its actual form, but encrypts the key value with public keys of all users from a specified role and then stores these multiple encrypted copies (i.e. share keys) in the configuration system.
- The key provider retrieves the actual key value by using the temporarily stored Private key of a user. 
- Generates a role key for each role upon module installation, updates the role key upon a new user addition/removal from that role, adds a role key upon role creation, removes the role key upon role removal.
### Updates over the PR till 6/16:
- **All users with "administer permissions" permission are given complete control over all Role keys.**
-  **Tests for Role keys management have been added. Testing is not very thorough at this moment.**
